### PR TITLE
fix(issues/50): Check useTabs setting when indenting attributes

### DIFF
--- a/packages/gformat-hast-to-html/lib/index.js
+++ b/packages/gformat-hast-to-html/lib/index.js
@@ -34,6 +34,8 @@ function toHTML(node, options) {
       safe: settings.allowDangerousCharacters ? 0 : 1,
       schema: settings.space === 'svg' ? svg : html,
       omit: settings.omitOptionalTags && omission,
+      useTabs,
+      settings: {tabWidth: settings.tabWidth || 2},
       quote: quote,
       printWidth: printWidth,
       tabWidth: tabWidth,

--- a/packages/gformat-html-formatter/test/fixtures/issue-50-use-tabs/config.json
+++ b/packages/gformat-html-formatter/test/fixtures/issue-50-use-tabs/config.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "tabWidth": 4,
+  "useTabs": true
+}

--- a/packages/gformat-html-formatter/test/fixtures/issue-50-use-tabs/input.html
+++ b/packages/gformat-html-formatter/test/fixtures/issue-50-use-tabs/input.html
@@ -1,0 +1,6 @@
+<div>
+  <input *ngIf="a long long condition..........................................................."
+  class="test-class"
+  type="text"
+  />
+  </div>

--- a/packages/gformat-html-formatter/test/fixtures/issue-50-use-tabs/output.html
+++ b/packages/gformat-html-formatter/test/fixtures/issue-50-use-tabs/output.html
@@ -1,0 +1,5 @@
+<div>
+	<input *ngIf="a long long condition..........................................................."
+		class="test-class"
+		type="text" />
+</div>

--- a/packages/gformat-html-formatter/test/fixtures/print-width-nested-tabs/output.html
+++ b/packages/gformat-html-formatter/test/fixtures/print-width-nested-tabs/output.html
@@ -1,8 +1,8 @@
 <form #heroForm FOO-BAR="test" onTest="Test" FOO-BAR2="test" onTest2="Testdded">
 	<div #heroForm
-			 FOO-BAR="test"
-			 onTest="Test"
-			 FOO-BAR2="test"
-			 onTest2="TestddesdT">
+			FOO-BAR="test"
+			onTest="Test"
+			FOO-BAR2="test"
+			onTest2="TestddesdT">
 	</div>
 </form>


### PR DESCRIPTION
- Safely check node.data properties
- Fix closeEmpty and tightClose settings being ignored
- Fix useTabs being ignored #50 